### PR TITLE
Create UUID for job objects

### DIFF
--- a/src/jso_backend/api/models/job_api_model.py
+++ b/src/jso_backend/api/models/job_api_model.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import date
 from typing import Any
 
@@ -34,7 +35,7 @@ class JobReceive(JobBase):
 
 
 class JobSend(JobBase):
-    id: int
+    id: uuid.UUID
     process_steps: list[ProcessStepApiModel]
 
 

--- a/src/jso_backend/api/routers/job_router.py
+++ b/src/jso_backend/api/routers/job_router.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import APIRouter, HTTPException
 
 from jso_backend.api.converters.job_converter import JobConverter
@@ -22,7 +24,7 @@ async def get_list_of_jobs():
 
 
 @router.get("/{job_id}", response_model=JobSend)
-async def get_job(job_id: int):
+async def get_job(job_id: UUID):
     try:
         job_entity: JobEntity = await JobService().get_job_by_id(id=job_id)
         job: JobSend = JobConverter().from_job_entity_to_job_api(job_entity=job_entity)
@@ -40,7 +42,7 @@ async def create_job(job: JobReceive):
 
 
 @router.patch("/{job_id}", response_model=JobSend)
-async def update_job(job_id: int, job: JobUpdate):
+async def update_job(job_id: UUID, job: JobUpdate):
     try:
         job_process: JobProcess | None = None
         if job.process_steps is not None:
@@ -59,7 +61,7 @@ async def update_job(job_id: int, job: JobUpdate):
 
 
 @router.delete("/{job_id}")
-async def delete_job(job_id: int):
+async def delete_job(job_id: UUID):
     try:
         await JobService().delete_job_by_id(job_id)
     except JobNotFoundError as error:

--- a/src/jso_backend/business_logic/services/job_service.py
+++ b/src/jso_backend/business_logic/services/job_service.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import UUID
 
 from jso_backend.business_logic.logic.job_logic import JobLogic
 from jso_backend.business_logic.validators.job_validator import JobValidator
@@ -9,7 +10,7 @@ from jso_backend.domain.job_process import JobProcess
 
 
 class JobService:
-    async def get_job_by_id(self, id: int) -> JobEntity:
+    async def get_job_by_id(self, id: UUID) -> JobEntity:
         async with UnitOfWork().create() as unit_of_work:
             job: JobEntity = await JobDataAccess(session=unit_of_work).get_job_by_id(job_id=id)
             return job
@@ -25,7 +26,7 @@ class JobService:
             return created_job
 
     async def update_job(
-        self, id: int, job_details: dict[str, Any], job_process: JobProcess | None = None
+        self, id: UUID, job_details: dict[str, Any], job_process: JobProcess | None = None
     ) -> JobEntity:
         async with UnitOfWork().create() as unit_of_work:
             job_access_data: JobDataAccess = JobDataAccess(unit_of_work)
@@ -41,7 +42,7 @@ class JobService:
             )
             return updated_job
 
-    async def delete_job_by_id(self, id: int) -> None:
+    async def delete_job_by_id(self, id: UUID) -> None:
         async with UnitOfWork().create() as unit_of_work:
             job_data_access: JobDataAccess = JobDataAccess(session=unit_of_work)
             await job_data_access.get_job_by_id(job_id=id)

--- a/src/jso_backend/data_access/converters/job_converter.py
+++ b/src/jso_backend/data_access/converters/job_converter.py
@@ -36,5 +36,5 @@ class JobDBConverter:
             process_steps=ProcessStepDBConverter().convert_list_of_process_step_entity_to_list_of_dict(
                 job_process=job.process_steps
             ),
-            id=job.id if job.id else None,
+            id=job.id,
         )

--- a/src/jso_backend/data_access/dal_interfaces/job_data_access_interface.py
+++ b/src/jso_backend/data_access/dal_interfaces/job_data_access_interface.py
@@ -1,12 +1,13 @@
 from abc import ABC, abstractmethod
 from typing import Any
+from uuid import UUID
 
 from jso_backend.domain.job_entity import JobEntity
 
 
 class IJobDataAccess(ABC):
     @abstractmethod
-    async def get_job_by_id(self, job_id: int) -> JobEntity:
+    async def get_job_by_id(self, job_id: UUID) -> JobEntity:
         pass
 
     @abstractmethod
@@ -18,9 +19,9 @@ class IJobDataAccess(ABC):
         pass
 
     @abstractmethod
-    async def update_job(self, job_id: int, job_data: dict[str, Any]) -> JobEntity:
+    async def update_job(self, job_id: UUID, job_data: dict[str, Any]) -> JobEntity:
         pass
 
     @abstractmethod
-    def delete_job(self, job_id: int) -> None:
+    def delete_job(self, job_id: UUID) -> None:
         pass

--- a/src/jso_backend/data_access/job_data_access.py
+++ b/src/jso_backend/data_access/job_data_access.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import UUID
 
 from sqlmodel import Session, select
 
@@ -15,7 +16,7 @@ class JobDataAccess(IJobDataAccess):
     def __init__(self, session: Session) -> None:
         self.db_session = session
 
-    async def get_job_by_id(self, job_id: int) -> JobEntity:
+    async def get_job_by_id(self, job_id: UUID) -> JobEntity:
         db_job: DBJobModel | None = self.db_session.get(DBJobModel, job_id)
         if not db_job:
             raise JobNotFoundError(id=job_id)
@@ -43,7 +44,7 @@ class JobDataAccess(IJobDataAccess):
         job_entity: JobEntity = JobDBConverter().convert_db_job_to_job_entity(db_job)
         return job_entity
 
-    async def update_job(self, job_id: int, job_data: dict[str, Any]) -> JobEntity:
+    async def update_job(self, job_id: UUID, job_data: dict[str, Any]) -> JobEntity:
         db_job: DBJobModel | None = self.db_session.get(DBJobModel, job_id)
         if not db_job:
             raise JobNotFoundError(id=job_id)
@@ -55,7 +56,7 @@ class JobDataAccess(IJobDataAccess):
         updated_job: JobEntity = JobDBConverter().convert_db_job_to_job_entity(db_job)
         return updated_job
 
-    def delete_job(self, job_id: int) -> None:
+    def delete_job(self, job_id: UUID) -> None:
         db_job: DBJobModel | None = self.db_session.get(DBJobModel, job_id)
         if not db_job:
             raise JobNotFoundError(id=job_id)

--- a/src/jso_backend/domain/exceptions/job_not_found_exception.py
+++ b/src/jso_backend/domain/exceptions/job_not_found_exception.py
@@ -1,4 +1,7 @@
+from uuid import UUID
+
+
 class JobNotFoundError(Exception):
-    def __init__(self, *args: object, id: int) -> None:
+    def __init__(self, *args: object, id: UUID) -> None:
         super().__init__(*args)
         self.message = f"Job with id {id} not found"

--- a/src/jso_backend/domain/job_entity.py
+++ b/src/jso_backend/domain/job_entity.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import date
 from typing import Any
 
@@ -10,7 +11,7 @@ from jso_backend.domain.job_status_type import JobStatus
 class JobEntity(BaseModel, validate_assignment=True):
     company_name: str = Field(min_length=1, max_length=50)
     role: str = Field(min_length=1, max_length=50)
-    id: int | None = None
+    id: uuid.UUID = uuid.uuid4()
     status: JobStatus = JobStatus.PENDING
     creation_date: date | None = date.today()
     job_link: str | None = ""

--- a/src/jso_backend/models/job_model.py
+++ b/src/jso_backend/models/job_model.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import date
 from typing import Any
 
@@ -7,6 +8,12 @@ from jso_backend.domain.job_status_type import JobStatus
 
 
 class DBJobModel(SQLModel, table=True):
+    id: uuid.UUID = Field(
+        default_factory=uuid.uuid4,
+        primary_key=True,
+        index=True,
+        nullable=False,
+    )
     creation_date: date | None = date.today()
     company_name: str
     role: str
@@ -14,5 +21,4 @@ class DBJobModel(SQLModel, table=True):
     job_link: str | None = None
     about: str | None = None
     tech_stack: list[str] = Field(sa_column=Column(JSON))
-    id: int | None = Field(default=None, primary_key=True)
     process_steps: list[dict[str, Any]] = Field(sa_column=Column(JSON))


### PR DESCRIPTION
- Update DB job_model to contain UUID instead of id of type int.
- Update job_api models to contain UUID instead of id of type int.
- Update job routes in the job_router module to get UUID as job_id in path params.
- Update job_data_access_interface and job_data_access to work with job UUID.